### PR TITLE
Attempt to expand secondary space with ununsed space from first space

### DIFF
--- a/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
@@ -215,20 +215,10 @@ public class BruteForcePackager extends Packager {
 
 			Space remainder = nextPlacement.getSpace().getRemainder();
 			if (box.getWeight() <= holder.getFreeWeight()) {
+				
+				Space nextSpace = null;
 				if (box.fitsInside3D(remainder)) {
-
-					remainderPlacement.setBox(box);
-
-					index++;
-
-					remainderPlacement.getSpace().copyFrom(remainder);
-					remainderPlacement.getSpace().setParent(remainder);
-					remainderPlacement.getSpace().getRemainder().setParent(remainder);
-
-					index = fit2D(rotator, index, placements, holder, remainderPlacement, interrupt);
-					if(index == -1) {
-						return -1;
-					}
+					nextSpace = remainder;
 				} else {
 					// is it possible to expand the remainder / secondary
 					// with space not used in the primary space?
@@ -256,8 +246,7 @@ public class BruteForcePackager extends Packager {
 						}
 					}
 
-					// see if the box firts now
-					Space nextSpace = null;
+					// see if the box fits now
 					if(box.fitsInside3D(widthRemainder)) {
 						nextSpace = widthRemainder;
 					} 
@@ -266,20 +255,19 @@ public class BruteForcePackager extends Packager {
 							nextSpace = depthRemainder;
 						}
 					}
-					
-					if(nextSpace != null) {
-						remainderPlacement.setBox(box);
+				}					
+				if(nextSpace != null) {
+					remainderPlacement.setBox(box);
 
-						index++;
+					index++;
 
-						remainderPlacement.getSpace().copyFrom(nextSpace);
-						remainderPlacement.getSpace().setParent(nextSpace);
-						remainderPlacement.getSpace().getRemainder().setParent(nextSpace);
+					remainderPlacement.getSpace().copyFrom(nextSpace);
+					remainderPlacement.getSpace().setParent(nextSpace);
+					remainderPlacement.getSpace().getRemainder().setParent(nextSpace);
 
-						index = fit2D(rotator, index, placements, holder, remainderPlacement, interrupt);
-						if(index == -1) {
-							return -1;
-						}
+					index = fit2D(rotator, index, placements, holder, remainderPlacement, interrupt);
+					if(index == -1) {
+						return -1;
 					}
 				}
 			}

--- a/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
@@ -228,31 +228,46 @@ public class BruteForcePackager extends Packager {
 					} else {
 						remainder.setDepth(space.getDepth());
 					}
-					
-					// cut out the area which is already in use, leaving two edges
-					Space depthRemainder = remainder; //
-					Space widthRemainder = new Space(remainder);
-
-					for(int i = fromIndex; i < index; i++) {
-						Placement placement = placements.get(i);
+					if (box.fitsInside3D(remainder)) {
+						// cut out the area which is already in use, leaving two edges
+						Space depthRemainder = remainder; //
+						Space widthRemainder = new Space(remainder);
+	
+						for(int i = fromIndex; i < index; i++) {
+							Placement placement = placements.get(i);
+							
+							if(widthRemainder.intersectsY(placement) && widthRemainder.intersectsX(placement)) {
+								// there is overlap, subtract area
+								widthRemainder.subtractX(placement);
+								
+								if (!box.fitsInside3D(widthRemainder)) {
+									break;
+								}
+							}
+						}
+	
+						for(int i = fromIndex; i < index; i++) {
+							Placement placement = placements.get(i);
+							
+							if(depthRemainder.intersectsY(placement) && depthRemainder.intersectsX(placement)) {
+								// there is overlap, subtract area
+								depthRemainder.subtractY(placement);
+								
+								if (!box.fitsInside3D(depthRemainder)) {
+									break;
+								}
+							}
+						}
+	
+						// see if the box fits now
+						if(box.fitsInside3D(widthRemainder)) {
+							nextSpace = widthRemainder;
+						}
 						
-						if(widthRemainder.intersectsY(placement) && widthRemainder.intersectsX(placement)) {
-							// there is overlap, subtract area
-							widthRemainder.subtractX(placement);
-						}
-						if(depthRemainder.intersectsY(placement) && depthRemainder.intersectsX(placement)) {
-							// there is overlap, subtract area
-							depthRemainder.subtractY(placement);
-						}
-					}
-
-					// see if the box fits now
-					if(box.fitsInside3D(widthRemainder)) {
-						nextSpace = widthRemainder;
-					} 
-					if(box.fitsInside3D(depthRemainder)) {
-						if(nextSpace == null || depthRemainder.getVolume() > nextSpace.getVolume()) {
-							nextSpace = depthRemainder;
+						if(box.fitsInside3D(depthRemainder)) {
+							if(nextSpace == null || depthRemainder.getVolume() > nextSpace.getVolume()) {
+								nextSpace = depthRemainder;
+							}
 						}
 					}
 				}					

--- a/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
@@ -264,10 +264,8 @@ public class BruteForcePackager extends Packager {
 							nextSpace = widthRemainder;
 						}
 						
-						if(box.fitsInside3D(depthRemainder)) {
-							if(nextSpace == null || depthRemainder.getVolume() > nextSpace.getVolume()) {
-								nextSpace = depthRemainder;
-							}
+						if(box.fitsInside3D(depthRemainder) && (nextSpace == null || depthRemainder.getVolume() > nextSpace.getVolume())) {
+							nextSpace = depthRemainder;
 						}
 					}
 				}					

--- a/core/src/main/java/com/github/skjolber/packing/Container.java
+++ b/core/src/main/java/com/github/skjolber/packing/Container.java
@@ -105,6 +105,13 @@ public class Container extends Box {
 
 		return levels.add(element);
 	}
+	
+	public Level currentLevel() {
+		if(!levels.isEmpty()) {
+			return levels.get(levels.size() - 1);
+		}
+		return null;
+	}
 
 	public int getStackHeight() {
 		return stackHeight + currentLevelStackHeight();

--- a/core/src/main/java/com/github/skjolber/packing/LargestAreaFitFirstPackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/LargestAreaFitFirstPackager.java
@@ -443,10 +443,8 @@ public class LargestAreaFitFirstPackager extends Packager {
 			return 0;
 		} else if(nextPlacementSpace == spaces[2]) {
 			return 3;
-		} else if(nextPlacementSpace == spaces[3]) {
+		} else { // if(nextPlacementSpace == spaces[3]) {
 			return 2;
-		} else {
-			throw new RuntimeException();
 		}
 	}	
 	

--- a/core/src/main/java/com/github/skjolber/packing/LargestAreaFitFirstPackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/LargestAreaFitFirstPackager.java
@@ -313,12 +313,25 @@ public class LargestAreaFitFirstPackager extends Packager {
 						if(widthRemainder.intersectsY(placement) && widthRemainder.intersectsX(placement)) {
 							// there is overlap, subtract area
 							widthRemainder.subtractX(placement);
+							
+							if (widthRemainder.getWidth() == 0) {
+								break;
+							}							
 						}
+					}
+					
+					for(int i = count; i < currentLevel.size(); i++) {
+						Placement placement = currentLevel.get(i);
+						
 						if(depthRemainder.intersectsY(placement) && depthRemainder.intersectsX(placement)) {
 							// there is overlap, subtract area
 							depthRemainder.subtractY(placement);
+							
+							if (depthRemainder.getDepth() == 0) {
+								break;
+							}							
 						}
-					}
+					}					
 
 					Box nextBox = null;
 					Space nextSpace = null;

--- a/core/src/main/java/com/github/skjolber/packing/Placement.java
+++ b/core/src/main/java/com/github/skjolber/packing/Placement.java
@@ -94,5 +94,5 @@ public class Placement {
 		return startZ <= placement.getSpace().getZ() + placement.getBox().getHeight() - 1 &&
 				placement.getSpace().getZ() + placement.getBox().getHeight() - 1 <= endZ;
 
-	}	
+	}
 }

--- a/core/src/main/java/com/github/skjolber/packing/Space.java
+++ b/core/src/main/java/com/github/skjolber/packing/Space.java
@@ -2,6 +2,14 @@ package com.github.skjolber.packing;
 
 public class Space extends Dimension {
 
+	protected static boolean between(int start, int value, int end) {
+		return start <= value && value <= end;
+	}
+	
+	protected boolean intersects(int start, int end, int value, int distance) {
+		return between(start, value, end) || between(start, value + distance, end);
+	}
+
 	private Space parent;
 	private Space remainder;
 
@@ -138,7 +146,6 @@ public class Space extends Dimension {
 	}
 
 	public boolean intersectsY(Space space) {
-
 		int startY = space.getY();
 		int endY = startY + space.getDepth() - 1;
 	
@@ -146,16 +153,10 @@ public class Space extends Dimension {
 	}
 
 	public boolean intersectsY(int startY, int endY) {
-
-		if (startY <= y && y <= endY) {
-			return true;
-		}
-
-		return startY <= y + depth && y + depth <= endY;
+		return intersects(startY, endY, y, depth);
 	}
 
 	public boolean intersectsX(Space space) {
-
 		int startX = space.getX();
 		int endX = startX + space.getWidth() - 1;
 		
@@ -163,12 +164,7 @@ public class Space extends Dimension {
 	}
 	
 	public boolean intersectsX(int startX, int endX) {
-		if (startX <= x && x <= endX) {
-			return true;
-		}
-
-		return startX <= x + width && x + width <= endX;
-
+		return intersects(startX, endX, x, width);
 	}
 
 	public boolean intersectsZ(Space space) {
@@ -179,16 +175,11 @@ public class Space extends Dimension {
 	}
 
 	public boolean intersectsZ(int startZ, int endZ) {
-		if (startZ <= z && z <= endZ) {
-			return true;
-		}
-
-		return startZ <= z + height && z + height <= endZ;
-
+		return intersects(startZ, endZ, z, height);
 	}
 
 	public boolean intersects(Placement placement) {
-		return false;
+		return intersectsX(placement) && intersectsY(placement) && intersectsZ(placement);
 	}
 	
 	public boolean intersectsY(Placement placement) {
@@ -232,5 +223,6 @@ public class Space extends Dimension {
 			calculateVolume();
 		}
 	}
+	
 
 }

--- a/core/src/main/java/com/github/skjolber/packing/Space.java
+++ b/core/src/main/java/com/github/skjolber/packing/Space.java
@@ -141,7 +141,7 @@ public class Space extends Dimension {
 		this.height = h;
 	}
 
-	boolean intersects(Space space) {
+	public boolean intersects(Space space) {
 		return intersectsX(space) && intersectsY(space) && intersectsZ(space);
 	}
 

--- a/core/src/main/java/com/github/skjolber/packing/Space.java
+++ b/core/src/main/java/com/github/skjolber/packing/Space.java
@@ -224,5 +224,16 @@ public class Space extends Dimension {
 		}
 	}
 	
+	public void subtractZ(Placement placement) {
+		int endZ = placement.getSpace().getZ() + placement.getBox().getHeight();
+		
+		if(endZ > z) {
+			height -= endZ - z;
+			
+			z = endZ;
+			
+			calculateVolume();
+		}
+	}	
 
 }

--- a/core/src/main/java/com/github/skjolber/packing/Space.java
+++ b/core/src/main/java/com/github/skjolber/packing/Space.java
@@ -34,7 +34,10 @@ public class Space extends Dimension {
 	}
 
 	public Space() {
-		super();
+	}
+	
+	public Space(Space clone) {
+		copyFrom(clone);
 	}
 
 	public Space(Space parent, String name, int w, int d, int h, int x, int y, int z) {
@@ -130,5 +133,104 @@ public class Space extends Dimension {
 		this.height = h;
 	}
 
+	boolean intersects(Space space) {
+		return intersectsX(space) && intersectsY(space) && intersectsZ(space);
+	}
+
+	public boolean intersectsY(Space space) {
+
+		int startY = space.getY();
+		int endY = startY + space.getDepth() - 1;
+	
+		return intersectsY(startY, endY);
+	}
+
+	public boolean intersectsY(int startY, int endY) {
+
+		if (startY <= y && y <= endY) {
+			return true;
+		}
+
+		return startY <= y + depth && y + depth <= endY;
+	}
+
+	public boolean intersectsX(Space space) {
+
+		int startX = space.getX();
+		int endX = startX + space.getWidth() - 1;
+		
+		return intersectsX(startX, endX);
+	}
+	
+	public boolean intersectsX(int startX, int endX) {
+		if (startX <= x && x <= endX) {
+			return true;
+		}
+
+		return startX <= x + width && x + width <= endX;
+
+	}
+
+	public boolean intersectsZ(Space space) {
+		int startZ = space.getZ();
+		int endZ = startZ + space.getHeight() - 1;
+
+		return intersectsZ(startZ, endZ);
+	}
+
+	public boolean intersectsZ(int startZ, int endZ) {
+		if (startZ <= z && z <= endZ) {
+			return true;
+		}
+
+		return startZ <= z + height && z + height <= endZ;
+
+	}
+
+	public boolean intersects(Placement placement) {
+		return false;
+	}
+	
+	public boolean intersectsY(Placement placement) {
+		int startY = placement.getSpace().getY();
+		int endY = startY + placement.getBox().getDepth() - 1;
+		return intersectsY(startY, endY);
+	}
+	
+	public boolean intersectsX(Placement placement) {
+		int startX = placement.getSpace().getX();
+		int endX = startX + placement.getBox().getWidth() - 1;
+		return intersectsY(startX, endX);
+	}
+
+	public boolean intersectsZ(Placement placement) {
+		int startZ = placement.getSpace().getZ();
+		int endZ = startZ + placement.getBox().getHeight() - 1;
+		return intersectsZ(startZ, endZ);
+	}
+
+	public void subtractX(Placement placement) {
+		int endX = placement.getSpace().getX() + placement.getBox().getWidth();
+		
+		if(endX > x) {
+			width -= endX - x;
+			
+			x = endX;
+			
+			calculateVolume();
+		}
+	}
+
+	public void subtractY(Placement placement) {
+		int endY = placement.getSpace().getY() + placement.getBox().getDepth();
+		
+		if(endY > y) {
+			depth -= endY - y;
+			
+			y = endY;
+			
+			calculateVolume();
+		}
+	}
 
 }

--- a/core/src/test/java/com/github/skjolber/packing/BruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/BruteForcePackagerTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -603,12 +601,28 @@ class BruteForcePackagerTest extends AbstractPackagerTest {
         products.add(new BoxItem(new Box("Product 3", 299, 299, 99, 25), 1));
         products.add(new BoxItem(new Box("Product 4", 99, 99, 99, 25), 1));
         List<Container> containers = packager.packList(products, maxContainers, System.currentTimeMillis() + 15000);
-        assertEquals(2, containers.size());
+        assertEquals(1, containers.size());
         assertEquals(containers.get(0).getName(), "Box 3");
-        assertEquals(containers.get(0).getLevels().size(), 3);
-        
-        assertEquals(containers.get(1).getName(), "Box 1");
-        assertEquals(containers.get(1).getLevels().size(), 1);
+        assertEquals(containers.get(0).getLevels().size(), 1);
     }
-	
+
+	@Test
+	void testExpansionOfRemainderSpace() {
+		// issue 159
+		List<Container> containers = new ArrayList<>();
+		Container container = new Container("X",100, 36, 1, 1000);
+		containers.add(container);
+
+		List<BoxItem> products = new ArrayList<>();
+		products.add(new BoxItem(new Box("1", 1, 18, 90, 1)));
+		products.add(new BoxItem(new Box("2", 1, 18, 90, 1)));
+		products.add(new BoxItem(new Box("3", 1, 36, 3, 1)));
+		products.add(new BoxItem(new Box("4", 1, 36, 3, 1)));
+		
+		BruteForcePackager packager = new BruteForcePackager(containers, true, true);
+		Container pack = packager.pack(products, Long.MAX_VALUE);
+		print(pack);
+
+		assertEquals(pack.getLevels().size(), 1);
+	}
 }

--- a/core/src/test/java/com/github/skjolber/packing/BruteForcePropertyBasedTests.java
+++ b/core/src/test/java/com/github/skjolber/packing/BruteForcePropertyBasedTests.java
@@ -1,7 +1,6 @@
 package com.github.skjolber.packing;
 
 import net.jqwik.api.*;
-import net.jqwik.api.arbitraries.IntegerArbitrary;
 import net.jqwik.api.constraints.IntRange;
 import net.jqwik.api.constraints.Size;
 

--- a/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackager2DTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackager2DTest.java
@@ -155,27 +155,29 @@ class LargestAreaFitFirstPackager2DTest extends AbstractPackagerTest {
 		List<BoxItem> products = new ArrayList<>();
 
 		for(int i = 0; i < 4; i++) {
-			products.add(new BoxItem(new Box("K", 1, 1, 1, 0), 1));
+			products.add(new BoxItem(new Box("K" + i, 1, 1, 1, 0), 1));
 		}
 
 		Container fits = packager.pack(products);
 		assertNotNull(fits);
 		assertEquals(fits.getLevels().size(), 1);
 
+		print(fits);
+
 		assertThat(fits.get(0, 0).getSpace().getX(), is(0));
 		assertThat(fits.get(0, 0).getSpace().getY(), is(0));
 
-		assertThat(fits.get(0, 1).getSpace().getX(), is(0));
-		assertThat(fits.get(0, 1).getSpace().getY(), is(1));
-
-		assertThat(fits.get(0, 3).getSpace().getX(), is(1));
-		assertThat(fits.get(0, 3).getSpace().getY(), is(1));
+		assertThat(fits.get(0, 1).getSpace().getX(), is(1));
+		assertThat(fits.get(0, 1).getSpace().getY(), is(0));
 
 		assertThat(fits.get(0, 2).getSpace().getX(), is(1));
-		assertThat(fits.get(0, 2).getSpace().getY(), is(0));
+		assertThat(fits.get(0, 2).getSpace().getY(), is(1));
 
-		print(fits);
+		assertThat(fits.get(0, 3).getSpace().getX(), is(0));
+		assertThat(fits.get(0, 3).getSpace().getY(), is(1));
+
 		validate(fits);
+
 	}
 
 	@Test

--- a/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackager3DTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackager3DTest.java
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -594,5 +592,40 @@ class LargestAreaFitFirstPackager3DTest extends AbstractPackagerTest {
 
 		validate(fits);
 	}
+
+	@Test
+	void testIssue158() {
+		List<Container> containers = new ArrayList<>();
+		containers.add(new Container("X",10, 10, 5, 1000));
+
+		List<BoxItem> products = new ArrayList<>();
+		for(int i = 0; i < 1000; i++) {
+			products.add(new BoxItem(new Box(Integer.toString(i), 1, 1, 1, 1)));
+		}
+		
+		LargestAreaFitFirstPackager packager = new LargestAreaFitFirstPackager(containers, false, true, true);
+		List<Container> fits = packager.packList(products, 50, Long.MAX_VALUE);
+		assertNotNull(fits);
+		assertEquals(fits.size(), 2);
+	}
 	
+	@Test
+	void testExpansionOfRemainderSpace() {
+		// issue 159
+		List<Container> containers = new ArrayList<>();
+		Container container = new Container("X",100, 36, 5, 1000);
+		containers.add(container);
+
+		List<BoxItem> products = new ArrayList<>();
+		products.add(new BoxItem(new Box("1", 1, 18, 90, 1)));
+		products.add(new BoxItem(new Box("2", 1, 18, 90, 1)));
+		products.add(new BoxItem(new Box("3", 1, 36, 3, 1)));
+		products.add(new BoxItem(new Box("4", 1, 36, 3, 1)));
+		
+		LargestAreaFitFirstPackager packager = new LargestAreaFitFirstPackager(containers, true, true, true);
+		Container pack = packager.pack(products, Long.MAX_VALUE);
+		print(pack);
+
+		assertEquals(pack.getLevels().size(), 1);
+	}	
 }


### PR DESCRIPTION
If nothing fits into the secondary (remainder) space, expand it with free space from primary space, if possible. 

Also fixes a potential bug with the secondary space fitting making the primare space fitting unavailable due to the weight constraint in the brute for packager.