### PR TITLE
Permutation rotator reuse

### DIFF
--- a/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
@@ -91,6 +91,7 @@ public class BruteForcePackager extends Packager {
 
 				int diff = rotator.nextRotation();
 				if(diff == -1) {
+					// no more rotations, continue to next permutation
 					holder.clear();
 
 					break;

--- a/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
@@ -68,14 +68,14 @@ public class BruteForcePackager extends Packager {
 				return null;
 			}
 			// iterator over all rotations
-			int keep = 0;
+			int index = 0;
 			do {
-				int count = pack(placements, holder.getFreeLevelSpace(), rotator, holder, keep, interrupt);
+				int count = pack(placements, holder.getFreeLevelSpace(), rotator, holder, index, interrupt);
 				if (count == Integer.MIN_VALUE) {
 					return null; // timeout
 				} 
 				if (count == placements.size()) {
-					if (accept()) {
+					if (accept(count)) {
 						result.setCount(count);
 						result.setState(rotator.getState());
 						
@@ -96,25 +96,11 @@ public class BruteForcePackager extends Packager {
 
 					break;
 				}
-				if(count > 0 && diff > 0) {
-
-					List<Level> levels = holder.getLevels();
-					Level lastLevel = levels.get(levels.size() - 1);
-					if(!holder.isFreeSpaceInLevel(levels.size() - 1)) {
-						// keep everything; start a new level
-					} else {
-						// reduce to closest full level and retry it
-						count -= lastLevel.size();
-					}
 				
-					keep = Math.min(diff, count);
-					if(keep > 0) {
-						holder.clear(keep);
-					} else {
-						holder.clear();
-					}
+				if(count >= 2 && diff >= 2) { // see whether we can reuse some previous calculations
+					index = holder.clearLevelsForBoxes(Math.min(diff, count));
 				} else {
-					keep = 0;
+					index = 0;
 					holder.clear();
 				}
 				
@@ -197,8 +183,8 @@ public class BruteForcePackager extends Packager {
 		return index;
 	}
 
-	protected boolean accept() {
-		return true;
+	protected boolean accept(int count) {
+		return count > 0;
 	}
 
 	protected static int fit2D(PermutationRotationIterator rotator, int index, List<Placement> placements, Container holder, Placement usedSpace, BooleanSupplier interrupt) {

--- a/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/BruteForcePackager.java
@@ -89,8 +89,8 @@ public class BruteForcePackager extends Packager {
 						}
 					}
 				}
-			} while (rotator.nextRotation());
-		} while (rotator.nextPermutation());
+			} while (rotator.nextRotation() != -1);
+		} while (rotator.nextPermutation() != -1);
 
 		return result;
 	}

--- a/core/src/main/java/com/github/skjolber/packing/Container.java
+++ b/core/src/main/java/com/github/skjolber/packing/Container.java
@@ -153,6 +153,9 @@ public class Container extends Box {
 	 */
 	
 	public Dimension getFreeLevelSpace() {
+		if(levels.isEmpty()) {
+			return this;
+		}
 		int remainder = height - getStackHeight();
 		if(remainder < 0) {
 			throw new IllegalArgumentException("Remaining free space is negative at " + remainder + " for " + this);
@@ -280,5 +283,36 @@ public class Container extends Box {
 
 	public Container rotate2D3D() {
 		return (Container)super.rotate2D3D();
+	}
+
+	public boolean isFreeSpaceInLevel(int i) {
+		// check if all volume is used
+		Level level = levels.get(i);
+		
+		long volume = (this.volume / getHeight()) * level.getHeight();
+		
+		for(Placement p : level) {
+			volume -= p.getBox().getVolume();
+		}
+		
+		return volume > 0;
+	}
+
+	public void clear(int keep) {
+		for (int i = 0; i < levels.size(); i++) {
+			Level level = levels.get(i);
+			
+			if(keep >= level.size()) {
+				keep -= level.size();
+			} else if(keep > 0) {
+				while(keep > 0) {
+					level.remove(level.size() - 1);
+					keep--;
+				}
+			} else {
+				levels.remove(i);
+				i--;
+			}
+		}
 	}
 }

--- a/core/src/main/java/com/github/skjolber/packing/Container.java
+++ b/core/src/main/java/com/github/skjolber/packing/Container.java
@@ -297,22 +297,58 @@ public class Container extends Box {
 		
 		return volume > 0;
 	}
+	
+	public void removeLevel(int index) {
+		Level level = levels.remove(index);
+		if(index != levels.size()) {
+			stackHeight -= level.getHeight();
+			stackWeight -= level.getWeight();
+		}
+	}
+	
+	/**
+	 * Clear levels up to and including a number of boxes 
+	 * 
+	 * @param limit number of boxes to keep
+	 * @return number of boxes kept
+	 */
 
-	public void clear(int keep) {
-		for (int i = 0; i < levels.size(); i++) {
+	public int clearLevelsForBoxes(int limit) {
+		int count = 0;
+		int i = 0;
+		while(limit > count && i < levels.size()) {
+			count += levels.get(i).size();
+			
+			i++;
+		}
+		
+		i--;
+		if(count == limit) {
+			// see if we can keep the last level
+			// if so there must be no free space in it
 			Level level = levels.get(i);
 			
-			if(keep >= level.size()) {
-				keep -= level.size();
-			} else if(keep > 0) {
-				while(keep > 0) {
-					level.remove(level.size() - 1);
-					keep--;
-				}
-			} else {
-				levels.remove(i);
-				i--;
+			long v = (volume / height) * level.getHeight();
+			for(Placement p : level) {
+				v -= p.getBox().getVolume();
 			}
+			
+			if(v == 0) {
+				// keep last level
+				i++;
+			} else {
+				// discard also the last level
+				count -= levels.get(i).size();
+			}
+		} else {
+			// discard also the last level
+			count -= levels.get(i).size();
 		}
+		
+		while(i < levels.size()) {
+			removeLevel(i);
+		}
+		
+		return count;
 	}
 }

--- a/core/src/main/java/com/github/skjolber/packing/Level.java
+++ b/core/src/main/java/com/github/skjolber/packing/Level.java
@@ -54,4 +54,5 @@ public class Level extends ArrayList<Placement>{
 		}
 	}
 
+
 }

--- a/core/src/main/java/com/github/skjolber/packing/impl/DefaultPermutationRotationIterator.java
+++ b/core/src/main/java/com/github/skjolber/packing/impl/DefaultPermutationRotationIterator.java
@@ -6,37 +6,6 @@ import java.util.List;
 
 import com.github.skjolber.packing.*;
 
-/**
- *
- * Rotation and permutations built into the same class. Minimizes the number of
- * rotations. <br>
- * <br>
- * The maximum number of combinations is n! * 6^n, however after accounting for
- * bounds and sides with equal lengths the number can be a lot lower (and this
- * number can be obtained before starting the calculation). <br>
- * <br>
- * Note that permutations are for the boxes which actually fit within this container.
- * <br>
- * <br>
- * Assumes a do-while approach:
- *
- * <pre>{@code
- * do {
- * 	do {
- * 		for (int i = 0; i < n; i++) {
- * 			Box box = instance.get(i);
- * 			// .. your code here
- * 		}
- * 	} while (instance.nextRotation());
- * } while (instance.nextPermutation());
- *
- * }</pre>
- *
- * @see <a href=
- *      "https://www.nayuki.io/page/next-lexicographical-permutation-algorithm"
- *      target="_top">next-lexicographical-permutation-algorithm</a>
- */
-
 public class DefaultPermutationRotationIterator implements PermutationRotationIterator {
 
 	public static PermutationRotation[] toRotationMatrix(List<BoxItem> list, boolean rotate3D) {
@@ -194,7 +163,7 @@ public class DefaultPermutationRotationIterator implements PermutationRotationIt
 	}
 
 	@Override
-	public boolean nextRotation() {
+	public int nextRotation() {
 		// next rotation
 		for(int i = 0; i < rotations.length; i++) {
 			if(rotations[i] < matrix[permutations[i]].getBoxes().length - 1) {
@@ -203,11 +172,11 @@ public class DefaultPermutationRotationIterator implements PermutationRotationIt
 				// reset all previous counters
 				System.arraycopy(reset, 0, rotations, 0, i);
 
-				return true;
+				return i;
 			}
 		}
 
-		return false;
+		return -1;
 	}
 
 	@Override
@@ -300,7 +269,7 @@ public class DefaultPermutationRotationIterator implements PermutationRotationIt
 	}
 
 	@Override
-	public boolean nextPermutation() {
+	public int nextPermutation() {
 		resetRotations();
 
 	    // Find longest non-increasing suffix
@@ -311,8 +280,9 @@ public class DefaultPermutationRotationIterator implements PermutationRotationIt
 
 	    // Are we at the last permutation already?
 	    if (i <= 0) {
-	        return false;
+	        return -1;
 	    }
+	    
 
 	    // Let array[i - 1] be the pivot
 	    // Find rightmost element that exceeds the pivot
@@ -321,6 +291,8 @@ public class DefaultPermutationRotationIterator implements PermutationRotationIt
 	        j--;
 	    // Now the value array[j] will become the new pivot
 	    // Assertion: j >= i
+
+	    int head = i - 1;
 
 	    // Swap the pivot with j
 	    int temp = permutations[i - 1];
@@ -338,7 +310,7 @@ public class DefaultPermutationRotationIterator implements PermutationRotationIt
 	    }
 
 	    // Successfully computed the next permutation
-	    return true;
+	    return head;
 	}
 
 	@Override

--- a/core/src/main/java/com/github/skjolber/packing/impl/ParallelPermutationRotationIterator.java
+++ b/core/src/main/java/com/github/skjolber/packing/impl/ParallelPermutationRotationIterator.java
@@ -126,7 +126,7 @@ public class ParallelPermutationRotationIterator extends DefaultPermutationRotat
 		return count;
 	}
 	
-	public boolean nextRotation(int index) {
+	public int nextRotation(int index) {
 		// next rotation
 		for(int i = 0; i < workUnits[index].rotations.length - PADDING; i++) {
 			if(workUnits[index].rotations[PADDING + i] < matrix[workUnits[index].permutations[PADDING + i]].getBoxes().length - 1) {
@@ -135,25 +135,25 @@ public class ParallelPermutationRotationIterator extends DefaultPermutationRotat
 				// reset all previous counters
 				System.arraycopy(reset, 0, workUnits[index].rotations, PADDING, i);
 
-				return true;
+				return i;
 			}
 		}
 
-		return false;
+		return -1;
 	}
 	
 
-	public boolean nextPermutation(int index) {
+	public int nextPermutation(int index) {
 		workUnits[index].count--;
 		if(workUnits[index].count > 0) {
 			System.arraycopy(reset, 0, workUnits[index].rotations, PADDING, reset.length);
 
 			return nextPermutation(workUnits[index].permutations);
 		}
-		return false;
+		return -1;
 	}
 	
-	protected boolean nextPermutation(int[] permutations) {
+	protected int nextPermutation(int[] permutations) {
 
 	    // Find longest non-increasing suffix
 
@@ -164,7 +164,7 @@ public class ParallelPermutationRotationIterator extends DefaultPermutationRotat
 
 	    // Are we at the last permutation already?
 	    if (i <= PADDING) {
-	        return false;
+	        return -1;
 	    }
 
 	    // Let array[i - 1] be the pivot
@@ -174,6 +174,8 @@ public class ParallelPermutationRotationIterator extends DefaultPermutationRotat
 	        j--;
 	    // Now the value array[j] will become the new pivot
 	    // Assertion: j >= i
+
+	    int head = i - 1 - PADDING;
 
 	    // Swap the pivot with j
 	    int temp = permutations[i - 1];
@@ -191,7 +193,7 @@ public class ParallelPermutationRotationIterator extends DefaultPermutationRotat
 	    }
 
 	    // Successfully computed the next permutation
-	    return true;
+	    return head;
 	}
 	
 

--- a/core/src/main/java/com/github/skjolber/packing/impl/ParallelPermutationRotationIteratorAdapter.java
+++ b/core/src/main/java/com/github/skjolber/packing/impl/ParallelPermutationRotationIteratorAdapter.java
@@ -30,7 +30,7 @@ public class ParallelPermutationRotationIteratorAdapter implements PermutationRo
 		delegate.removePermutations(removed);
 	}
 
-	public boolean nextRotation() {
+	public int nextRotation() {
 		return delegate.nextRotation(index);
 	}
 
@@ -42,7 +42,7 @@ public class ParallelPermutationRotationIteratorAdapter implements PermutationRo
 		return delegate.get(index, this.index);
 	}
 
-	public boolean nextPermutation() {
+	public int nextPermutation() {
 		return delegate.nextPermutation(index);
 	}
 

--- a/core/src/main/java/com/github/skjolber/packing/impl/PermutationRotationIterator.java
+++ b/core/src/main/java/com/github/skjolber/packing/impl/PermutationRotationIterator.java
@@ -2,6 +2,37 @@ package com.github.skjolber.packing.impl;
 
 import com.github.skjolber.packing.Box;
 
+/**
+*
+* Rotation and permutations built into the same interface. Minimizes the number of
+* rotations. <br>
+* <br>
+* The maximum number of combinations is n! * 6^n, however after accounting for
+* bounds and sides with equal lengths the number can be a lot lower (and this
+* number can be obtained before starting the calculation). <br>
+* <br>
+* Note that permutations are for the boxes which actually fit within this container.
+* <br>
+* <br>
+* Assumes a do-while approach:
+*
+* <pre>{@code
+* do {
+* 	do {
+* 		for (int i = 0; i < n; i++) {
+* 			Box box = instance.get(i);
+* 			// .. your code here
+* 		}
+* 	} while (instance.nextRotation() != -1);
+* } while (instance.nextPermutation() != -1);
+*
+* }</pre>
+*
+* @see <a href=
+*      "https://www.nayuki.io/page/next-lexicographical-permutation-algorithm"
+*      target="_top">next-lexicographical-permutation-algorithm</a>
+*/
+
 public interface PermutationRotationIterator extends PermutationSet {
 
 	int[] getPermutations();
@@ -10,9 +41,21 @@ public interface PermutationRotationIterator extends PermutationSet {
 	
 	Box get(int index);
 
-	boolean nextRotation();
+	/**
+	 * Next rotation.
+	 * 
+	 * @return change index, or -1 if none
+	 */
+	
+	int nextRotation();
 
-	boolean nextPermutation();
+	/**
+	 * Next permutation.
+	 * 
+	 * @return change index, or -1 if none
+	 */
+
+	int nextPermutation();
 
 	PermutationRotationState getState();
 

--- a/core/src/test/java/com/github/skjolber/packing/AbstractPackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/AbstractPackagerTest.java
@@ -1,13 +1,13 @@
 package com.github.skjolber.packing;
 
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import com.github.skjolber.packing.test.BouwkampCode;
-
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 abstract class AbstractPackagerTest {
 

--- a/core/src/test/java/com/github/skjolber/packing/BoxTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/BoxTest.java
@@ -6,8 +6,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.packing.Box;
-
 class BoxTest {
 
 	@Test

--- a/core/src/test/java/com/github/skjolber/packing/BruteForcePackagerBuilderTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/BruteForcePackagerBuilderTest.java
@@ -1,10 +1,11 @@
 package com.github.skjolber.packing;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 public class BruteForcePackagerBuilderTest {
 

--- a/core/src/test/java/com/github/skjolber/packing/BruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/BruteForcePackagerTest.java
@@ -667,4 +667,42 @@ class BruteForcePackagerTest extends AbstractPackagerTest {
 			}
 		}
 	}
+	
+	@Test
+	void testStackingRectanglesOnSquareWithReuse() {
+		int n = 12;
+		int boxesPerLevel = 4;
+
+		List<Container> containers = new ArrayList<>();
+		int levels = n / boxesPerLevel + (n % boxesPerLevel > 0 ? 1 : 0);
+
+		containers.add(new ValidatingContainer(2 * boxesPerLevel / 2, 1 * (boxesPerLevel / 2), 10 * levels, 0));
+
+		// first levels will be easy to populate
+		List<BoxItem> identialProducts = new ArrayList<>();
+		for(int i = 0; i < n - boxesPerLevel; i++) {
+			Box box = new Box(Integer.toString(i), 1, 2, 10, 0);
+			identialProducts.add(new BoxItem(box, 1));
+		}
+
+		// last level will require some more work
+		Box box = new Box("a", 3, 1, 10, 0);
+		box.rotate3D();
+		identialProducts.add(new BoxItem(box, 1));
+
+		box = new Box("b", 3, 1, 10, 0);
+		box.rotate3D();
+		identialProducts.add(new BoxItem(box, 1));
+
+		box = new Box("c", 2, 1, 10, 0);
+		box.rotate3D();
+		identialProducts.add(new BoxItem(box, 1));
+
+		
+		BruteForcePackager packager = new BruteForcePackager(containers);
+
+		Container fits = packager.pack(identialProducts);
+		assertNotNull(fits);
+		assertEquals(fits.getLevels().size(), levels);
+	}	
 }

--- a/core/src/test/java/com/github/skjolber/packing/BruteForcePropertyBasedTests.java
+++ b/core/src/test/java/com/github/skjolber/packing/BruteForcePropertyBasedTests.java
@@ -42,6 +42,7 @@ class BruteForcePropertyBasedTests {
 		//TODO: we could also randomly rotate the items
 		final List<Container> containers = largeEnoughContainers(item, countBySide);
 		System.out.printf("Fit %d repeated items into one of %d large enough containers\n", repeatedItems.getCount(), containers.size());
+		System.out.println(item);
 		final Container pack = new BruteForcePackager(containers).pack(singletonList(repeatedItems), Long.MAX_VALUE);
 		assertThat(pack).isNotNull();
 	}

--- a/core/src/test/java/com/github/skjolber/packing/BruteForcePropertyBasedTests.java
+++ b/core/src/test/java/com/github/skjolber/packing/BruteForcePropertyBasedTests.java
@@ -1,23 +1,21 @@
 package com.github.skjolber.packing;
 
-import net.jqwik.api.*;
-import net.jqwik.api.constraints.IntRange;
-import net.jqwik.api.constraints.Size;
+import static java.util.Collections.singletonList;
+import static net.jqwik.api.Arbitraries.integers;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.BoxItem;
-import com.github.skjolber.packing.BruteForcePackager;
-import com.github.skjolber.packing.Container;
-import com.github.skjolber.packing.Dimension;
-
-import static java.util.Collections.singletonList;
-import static net.jqwik.api.Arbitraries.integers;
-import static org.assertj.core.api.Assertions.assertThat;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.constraints.IntRange;
+import net.jqwik.api.constraints.Size;
 
 class BruteForcePropertyBasedTests {
 	// The maximum number of different, random items which can be reliably packed with brute force

--- a/core/src/test/java/com/github/skjolber/packing/ContainerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/ContainerTest.java
@@ -4,12 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.Container;
-import com.github.skjolber.packing.Dimension;
-import com.github.skjolber.packing.Placement;
-import com.github.skjolber.packing.Space;
-
 class ContainerTest {
 
 	@Test

--- a/core/src/test/java/com/github/skjolber/packing/DimensionTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/DimensionTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.packing.Dimension;
-
 class DimensionTest {
 
 	@Test

--- a/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackager2DTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackager2DTest.java
@@ -13,11 +13,6 @@ import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.BoxItem;
-import com.github.skjolber.packing.Container;
-import com.github.skjolber.packing.LargestAreaFitFirstPackager;
-
 class LargestAreaFitFirstPackager2DTest extends AbstractPackagerTest {
 
 	@Test

--- a/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackager3DTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackager3DTest.java
@@ -1,12 +1,14 @@
 package com.github.skjolber.packing;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 class LargestAreaFitFirstPackager3DTest extends AbstractPackagerTest {
 

--- a/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackagerBuilderTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/LargestAreaFitFirstPackagerBuilderTest.java
@@ -1,10 +1,11 @@
 package com.github.skjolber.packing;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 public class LargestAreaFitFirstPackagerBuilderTest {
 	

--- a/core/src/test/java/com/github/skjolber/packing/LevelTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/LevelTest.java
@@ -1,13 +1,8 @@
 package com.github.skjolber.packing;
 
-import org.junit.jupiter.api.Test;
-
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.Level;
-import com.github.skjolber.packing.Placement;
-import com.github.skjolber.packing.Space;
-
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 
 class LevelTest {

--- a/core/src/test/java/com/github/skjolber/packing/PackagerCombinationDemo.java
+++ b/core/src/test/java/com/github/skjolber/packing/PackagerCombinationDemo.java
@@ -5,12 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.BoxItem;
-import com.github.skjolber.packing.BruteForcePackager;
-import com.github.skjolber.packing.Container;
-import com.github.skjolber.packing.LargestAreaFitFirstPackager;
-
 /**
  * Illustrates how the LAFF packager and brute force packager can be used together.
  *

--- a/core/src/test/java/com/github/skjolber/packing/PackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/PackagerTest.java
@@ -1,6 +1,10 @@
 package com.github.skjolber.packing;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -13,14 +17,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.BoxItem;
-import com.github.skjolber.packing.BruteForcePackager;
-import com.github.skjolber.packing.Container;
-import com.github.skjolber.packing.LargestAreaFitFirstPackager;
 import com.github.skjolber.packing.impl.Adapter;
 import com.github.skjolber.packing.impl.PackResult;
 

--- a/core/src/test/java/com/github/skjolber/packing/ParallelBruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/ParallelBruteForcePackagerTest.java
@@ -11,11 +11,6 @@ import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.BoxItem;
-import com.github.skjolber.packing.BruteForcePackager;
-import com.github.skjolber.packing.Container;
-
 public class ParallelBruteForcePackagerTest {
 
 	@Test

--- a/core/src/test/java/com/github/skjolber/packing/SpaceTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/SpaceTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.packing.Space;
-
 class SpaceTest {
 
 	@Test

--- a/core/src/test/java/com/github/skjolber/packing/Visualizer.java
+++ b/core/src/test/java/com/github/skjolber/packing/Visualizer.java
@@ -1,10 +1,5 @@
 package com.github.skjolber.packing;
 
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.Container;
-import com.github.skjolber.packing.Level;
-import com.github.skjolber.packing.Placement;
-import com.github.skjolber.packing.Space;
 import com.indvd00m.ascii.render.Render;
 import com.indvd00m.ascii.render.api.ICanvas;
 import com.indvd00m.ascii.render.api.IContextBuilder;

--- a/core/src/test/java/com/github/skjolber/packing/impl/BinarySearchIteratorTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/impl/BinarySearchIteratorTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.packing.impl.BinarySearchIterator;
-
 class BinarySearchIteratorTest {
 
 	@Test

--- a/core/src/test/java/com/github/skjolber/packing/impl/BruteForcePackagerRuntimeEstimator.java
+++ b/core/src/test/java/com/github/skjolber/packing/impl/BruteForcePackagerRuntimeEstimator.java
@@ -33,7 +33,7 @@ public class BruteForcePackagerRuntimeEstimator {
 		}
 
 		@Override
-		protected boolean accept() {
+		protected boolean accept(int count) {
 			return false;
 		}
 	}

--- a/core/src/test/java/com/github/skjolber/packing/impl/BruteForcePackagerRuntimeEstimator.java
+++ b/core/src/test/java/com/github/skjolber/packing/impl/BruteForcePackagerRuntimeEstimator.java
@@ -1,11 +1,13 @@
 package com.github.skjolber.packing.impl;
 
-import com.github.skjolber.packing.*;
-import com.github.skjolber.packing.impl.DefaultPermutationRotationIterator;
-import com.github.skjolber.packing.impl.PermutationRotation;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.github.skjolber.packing.Box;
+import com.github.skjolber.packing.BoxItem;
+import com.github.skjolber.packing.BruteForcePackager;
+import com.github.skjolber.packing.Container;
+import com.github.skjolber.packing.Packager;
 
 public class BruteForcePackagerRuntimeEstimator {
 

--- a/core/src/test/java/com/github/skjolber/packing/impl/ParallelPermutationRotationIteratorTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/impl/ParallelPermutationRotationIteratorTest.java
@@ -2,8 +2,7 @@ package com.github.skjolber.packing.impl;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
+import static com.github.skjolber.packing.impl.PermutationRotationIteratorTest.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,11 +39,42 @@ public class ParallelPermutationRotationIteratorTest {
 			assertThat(nthIterator.getPermutations(0)).isEqualTo(iterator.getPermutations());
 
 			count++;
-		} while(nthIterator.nextPermutation(0) && iterator.nextPermutation());
+		} while(nthIterator.nextPermutation(0) != -1 && iterator.nextPermutation() != -1);
 
 		assertEquals( 5 * 4 * 3 * 2 * 1, count);
-		assertFalse(nthIterator.nextPermutation(0));
+		assertThat(nthIterator.nextPermutation(0)).isEqualTo(-1);
 	}
+	
+	@Test
+	void testPermutationDifference() {
+		Box container = new Box(9, 1, 1, 0);
+
+		List<BoxItem> products = new ArrayList<>();
+
+		products.add(new BoxItem(new Box("0", 1, 1, 3, 0), 1));
+		products.add(new BoxItem(new Box("1", 1, 1, 3, 0), 1));
+		products.add(new BoxItem(new Box("2", 1, 1, 3, 0), 1));
+		products.add(new BoxItem(new Box("3", 1, 1, 3, 0), 1));
+
+		ParallelPermutationRotationIterator nthIterator = new ParallelPermutationRotationIterator(products, container, true, 1);
+		
+		int count = 0;
+		do {
+			count++;
+			
+			int[] permutations = cloneArray(nthIterator.getPermutations(0));
+			
+			int length = nthIterator.nextPermutation(0);
+			
+			if(length == -1) {
+				break;
+			}
+			assertThat(firstDiffIndex(permutations, nthIterator.getPermutations(0))).isEqualTo(length);
+			
+		} while(true);
+
+		assertEquals(4 * 3 * 2 * 1, count);
+	}	
 
 	@Test
 	void testPermutationsMultipleWorkUnits() {
@@ -73,10 +103,10 @@ public class ParallelPermutationRotationIteratorTest {
 		do {
 			assertThat(nthIterator.getPermutations(1)).isEqualTo(iterator.getPermutations());
 			count++;
-		} while(nthIterator.nextPermutation(1) && iterator.nextPermutation());
+		} while(nthIterator.nextPermutation(1) != -1 && iterator.nextPermutation() != -1);
 
 		assertEquals( 5 * 4 * 3, count);
-		assertFalse(nthIterator.nextPermutation(1));
+		assertThat(nthIterator.nextPermutation(1)).isEqualTo(-1);
 	}
 
 	@Test
@@ -104,10 +134,11 @@ public class ParallelPermutationRotationIteratorTest {
 		do {
 			assertThat(nthIterator.getPermutations(1)).isEqualTo(iterator.getPermutations());
 			count++;
-		} while(nthIterator.nextPermutation(1) && iterator.nextPermutation());
+		} while(nthIterator.nextPermutation(1) != -1 && iterator.nextPermutation() != -1);
 
 		assertEquals( 8 * 7 * 6 * 5 * 4 * 3 * 2 * 1 / ((3 * 2 * 1) * (4 * 3 * 2 * 1) * 2), count);
-		assertFalse(nthIterator.nextPermutation(1));
+		
+		assertThat(nthIterator.nextPermutation(1)).isEqualTo(-1);
 	}
 	
 	public static long rankPerm(String perm) {

--- a/core/src/test/java/com/github/skjolber/packing/impl/ParallelPermutationRotationIteratorTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/impl/ParallelPermutationRotationIteratorTest.java
@@ -1,8 +1,10 @@
 package com.github.skjolber.packing.impl;
 
+import static com.github.skjolber.packing.impl.PermutationRotationIteratorTest.cloneArray;
+import static com.github.skjolber.packing.impl.PermutationRotationIteratorTest.firstDiffIndex;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static com.github.skjolber.packing.impl.PermutationRotationIteratorTest.*;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,8 +13,6 @@ import org.junit.jupiter.api.Test;
 
 import com.github.skjolber.packing.Box;
 import com.github.skjolber.packing.BoxItem;
-import com.github.skjolber.packing.impl.DefaultPermutationRotationIterator;
-import com.github.skjolber.packing.impl.ParallelPermutationRotationIterator;
 
 public class ParallelPermutationRotationIteratorTest {
 

--- a/core/src/test/java/com/github/skjolber/packing/impl/PermutationRotationIteratorTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/impl/PermutationRotationIteratorTest.java
@@ -1,21 +1,16 @@
 package com.github.skjolber.packing.impl;
 
 import static com.google.common.truth.Truth.assertThat;
-
-import org.assertj.core.util.Arrays;
-import org.junit.jupiter.api.Test;
-
-import com.github.skjolber.packing.Box;
-import com.github.skjolber.packing.BoxItem;
-import com.github.skjolber.packing.impl.DefaultPermutationRotationIterator;
-import com.github.skjolber.packing.impl.PermutationRotation;
-import com.github.skjolber.packing.impl.PermutationRotationIterator;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import com.github.skjolber.packing.Box;
+import com.github.skjolber.packing.BoxItem;
 
 class PermutationRotationIteratorTest {
 

--- a/core/src/test/java/com/github/skjolber/packing/impl/PermutationRotationIteratorTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/impl/PermutationRotationIteratorTest.java
@@ -1,5 +1,8 @@
 package com.github.skjolber.packing.impl;
 
+import static com.google.common.truth.Truth.assertThat;
+
+import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import com.github.skjolber.packing.Box;
@@ -35,7 +38,7 @@ class PermutationRotationIteratorTest {
 			int rotate = 0;
 			do {
 				rotate++;
-			} while(rotator.nextRotation());
+			} while(rotator.nextRotation() != -1);
 
 			assertEquals(count, rotate);
 		}
@@ -130,7 +133,7 @@ class PermutationRotationIteratorTest {
 			for(int i = 0; i < products.size(); i++) {
 				assertTrue(rotator.get(i).fitsInside3D(container));
 			}
-		} while(rotator.nextRotation());
+		} while(rotator.nextRotation() != -1);
 
 	}
 
@@ -151,9 +154,56 @@ class PermutationRotationIteratorTest {
 		int count = 0;
 		do {
 			count++;
-		} while(rotator.nextPermutation());
+		} while(rotator.nextPermutation() != -1);
 
 		assertEquals( 5 * 4 * 3 * 2 * 1, count);
+	}
+	
+	@Test
+	void testPermutationDifference() {
+		Box container = new Box(9, 1, 1, 0);
+
+		List<BoxItem> products = new ArrayList<>();
+
+		products.add(new BoxItem(new Box("0", 1, 1, 3, 0), 1));
+		products.add(new BoxItem(new Box("1", 1, 1, 3, 0), 1));
+		products.add(new BoxItem(new Box("2", 1, 1, 3, 0), 1));
+		products.add(new BoxItem(new Box("3", 1, 1, 3, 0), 1));
+
+		PermutationRotationIterator rotator = new DefaultPermutationRotationIterator(products, container, true);
+
+		
+		int count = 0;
+		do {
+			count++;
+			
+			int[] permutations = cloneArray(rotator.getPermutations());
+			
+			int length = rotator.nextPermutation();
+			
+			if(length == -1) {
+				break;
+			}
+			assertThat(firstDiffIndex(permutations, rotator.getPermutations())).isEqualTo(length);
+			
+		} while(true);
+
+		assertEquals(4 * 3 * 2 * 1, count);
+	}
+
+	public static int firstDiffIndex(int[] a, int[] b) {
+		for(int i = 0; i < a.length; i++) {
+			if(a[i] != b[i]) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	public static int[] cloneArray(int[] permutations) {
+		int[] clone = new int[permutations.length];
+		System.arraycopy(permutations, 0, clone, 0, permutations.length);
+		return clone;
 	}
 
 	@Test
@@ -170,7 +220,7 @@ class PermutationRotationIteratorTest {
 		int count = 0;
 		do {
 			count++;
-		} while(rotator.nextPermutation());
+		} while(rotator.nextPermutation() != -1);
 
 		assertEquals( (6 * 5 * 4 * 3 * 2 * 1) / ((4 * 3 * 2 * 1) * (2 * 1)), count);
 	}

--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.skjolber.3d-bin-container-packing</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2.11-SNAPSHOT</version>
+        <version>1.2.12-SNAPSHOT</version>
     </parent>
     <artifactId>jmh</artifactId>
     <name>JMH</name>

--- a/jmh/src/main/java/com/github/skjolber/jmh/MinimumAcceptableBruteForcePackager.java
+++ b/jmh/src/main/java/com/github/skjolber/jmh/MinimumAcceptableBruteForcePackager.java
@@ -1,0 +1,42 @@
+package com.github.skjolber.jmh;
+
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+import com.github.skjolber.packing.BruteForcePackager;
+import com.github.skjolber.packing.Container;
+import com.github.skjolber.packing.Placement;
+import com.github.skjolber.packing.impl.BruteForceResult;
+
+public class MinimumAcceptableBruteForcePackager extends BruteForcePackager {
+
+	private final int mimimumAcceptableCount;
+	private final boolean permutate;
+	private final boolean rotate;
+	
+	public MinimumAcceptableBruteForcePackager(List<Container> containers, int mimimumAcceptableCount, boolean permutate, boolean rotate) {
+		super(containers);
+		
+		this.mimimumAcceptableCount = mimimumAcceptableCount;
+		this.permutate = permutate;
+		this.rotate = rotate;
+	}
+
+	public MinimumAcceptableBruteForcePackager(List<Container> containers, boolean rotate3d, boolean binarySearch, int checkpointsPerDeadlineCheck, int mimimumAcceptableCount, boolean permutate, boolean rotate) {
+		super(containers, rotate3d, binarySearch, checkpointsPerDeadlineCheck);
+		
+		this.mimimumAcceptableCount = mimimumAcceptableCount;
+		this.permutate = permutate;
+		this.rotate = rotate;
+	}
+
+	@Override
+	protected boolean accept(int count) {
+		return count >= mimimumAcceptableCount;
+	}
+	
+	public BruteForceResult pack(List<Placement> placements, Container container, com.github.skjolber.packing.impl.PermutationRotationIterator rotator, BooleanSupplier interrupt) {
+		return super.pack(placements, container, new SinglePermutationRotationIterator(rotator, permutate, rotate), interrupt);
+	}
+
+}

--- a/jmh/src/main/java/com/github/skjolber/jmh/MinimumAcceptableParallelBruteForcePackager.java
+++ b/jmh/src/main/java/com/github/skjolber/jmh/MinimumAcceptableParallelBruteForcePackager.java
@@ -1,0 +1,53 @@
+package com.github.skjolber.jmh;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.BooleanSupplier;
+
+import com.github.skjolber.packing.Container;
+import com.github.skjolber.packing.ParallelBruteForcePackager;
+import com.github.skjolber.packing.Placement;
+import com.github.skjolber.packing.impl.BruteForceResult;
+import com.github.skjolber.packing.impl.PermutationRotationIterator;
+
+public class MinimumAcceptableParallelBruteForcePackager extends ParallelBruteForcePackager {
+
+	private final int mimimumAcceptableCount;
+	private final boolean permutate;
+	private final boolean rotate;
+	
+	public MinimumAcceptableParallelBruteForcePackager(List<Container> containers, int threads, int checkpointsPerDeadlineCheck, int mimimumAcceptableCount, boolean permutate, boolean rotate) {
+		super(containers, threads, checkpointsPerDeadlineCheck);
+		
+		this.mimimumAcceptableCount = mimimumAcceptableCount;
+		this.permutate = permutate;
+		this.rotate = rotate;
+	}
+	
+	public MinimumAcceptableParallelBruteForcePackager(List<Container> containers, int threads, boolean rotate3D, boolean binarySearch, int checkpointsPerDeadlineCheck, int mimimumAcceptableCount, boolean permutate, boolean rotate) {
+		super(containers, threads, rotate3D, binarySearch, checkpointsPerDeadlineCheck);
+		
+		this.mimimumAcceptableCount = mimimumAcceptableCount;
+		this.permutate = permutate;
+		this.rotate = rotate;
+	}
+	
+	public MinimumAcceptableParallelBruteForcePackager(List<Container> containers, ExecutorService executorService, int threads, boolean rotate3D, boolean binarySearch, int checkpointsPerDeadlineCheck, int mimimumAcceptableCount, boolean permutate, boolean rotate) {
+		super(containers, executorService, threads, rotate3D, binarySearch, checkpointsPerDeadlineCheck);
+		
+		this.mimimumAcceptableCount = mimimumAcceptableCount;
+		this.permutate = permutate;
+		this.rotate = rotate;
+	}
+
+
+	@Override
+	protected boolean accept(int count) {
+		return count >= mimimumAcceptableCount;
+	}
+	
+	public BruteForceResult pack(List<Placement> placements, Container container, PermutationRotationIterator rotator, BooleanSupplier interrupt) {
+		return super.pack(placements, container, new SinglePermutationRotationIterator(rotator, permutate, rotate), interrupt);
+	}
+}

--- a/jmh/src/main/java/com/github/skjolber/jmh/MinimumAcceptableParallelBruteForcePackager.java
+++ b/jmh/src/main/java/com/github/skjolber/jmh/MinimumAcceptableParallelBruteForcePackager.java
@@ -2,7 +2,6 @@ package com.github.skjolber.jmh;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.BooleanSupplier;
 
 import com.github.skjolber.packing.Container;

--- a/jmh/src/main/java/com/github/skjolber/jmh/PermutationPackagerState.java
+++ b/jmh/src/main/java/com/github/skjolber/jmh/PermutationPackagerState.java
@@ -16,7 +16,6 @@ import com.github.skjolber.packing.BoxItem;
 import com.github.skjolber.packing.BruteForcePackager;
 import com.github.skjolber.packing.BruteForcePackagerBuilder;
 import com.github.skjolber.packing.Container;
-import com.github.skjolber.packing.ParallelBruteForcePackager;
 import com.github.skjolber.packing.test.BouwkampCode;
 import com.github.skjolber.packing.test.BouwkampCodeDirectory;
 import com.github.skjolber.packing.test.BouwkampCodes;
@@ -24,15 +23,26 @@ import com.github.skjolber.packing.test.BouwkampCodes;
 @State(Scope.Benchmark)
 public class PermutationPackagerState {
 
-	private int count = 8;
-	private int nth = 20000;
+	private final int threadPoolSize;
+	private final int nth;
 	
-	private ExecutorService pool = Executors.newFixedThreadPool(count);
+	private ExecutorService pool;
 	
 	private List<BenchmarkSet> parallelBruteForcePackager = new ArrayList<>();
 	private List<BenchmarkSet> parallelBruteForcePackagerNth = new ArrayList<>();
 	private List<BenchmarkSet> bruteForcePackager = new ArrayList<>();
 	private List<BenchmarkSet> bruteForcePackagerNth = new ArrayList<>();
+
+	public PermutationPackagerState() {
+		this(8, 20000);
+	}
+
+	public PermutationPackagerState(int threadPoolSize, int nth) {
+		this.threadPoolSize = threadPoolSize;
+		this.nth = nth;
+		
+		this.pool = Executors.newFixedThreadPool(threadPoolSize);
+	}
 	
 	@Setup(Level.Trial)
 	public void init() {
@@ -65,7 +75,7 @@ public class PermutationPackagerState {
 				BruteForcePackagerBuilder multiThreadBuilder = BruteForcePackager.newBuilder().withContainers(containers);
 
 				multiThreadBuilder.withCheckpointsPerDeadlineCheck(1);
-				multiThreadBuilder.withThreads(count);
+				multiThreadBuilder.withThreads(threadPoolSize);
 				multiThreadBuilder.withExecutorService(pool);
 				
 				parallelBruteForcePackager.add(new BenchmarkSet(multiThreadBuilder, products));

--- a/jmh/src/main/java/com/github/skjolber/jmh/RotationPackagerState.java
+++ b/jmh/src/main/java/com/github/skjolber/jmh/RotationPackagerState.java
@@ -62,7 +62,7 @@ public class RotationPackagerState {
 		}
 		// verify that will not be able to package successful
 		if(bruteForcePackager.pack(identialProducts) != null) {
-			throw new RuntimeException();
+			throw new IllegalArgumentException();
 		}
 		
 		this.identialProducts = identialProducts;

--- a/jmh/src/main/java/com/github/skjolber/jmh/SinglePermutationRotationIterator.java
+++ b/jmh/src/main/java/com/github/skjolber/jmh/SinglePermutationRotationIterator.java
@@ -1,0 +1,63 @@
+package com.github.skjolber.jmh;
+
+import java.util.List;
+
+import com.github.skjolber.packing.Box;
+import com.github.skjolber.packing.impl.PermutationRotationIterator;
+import com.github.skjolber.packing.impl.PermutationRotationState;
+
+public class SinglePermutationRotationIterator implements PermutationRotationIterator {
+
+	private final PermutationRotationIterator iterator;
+	private final boolean permutate;
+	private final boolean rotate;
+	public SinglePermutationRotationIterator(PermutationRotationIterator iterator, boolean permutate, boolean rotate) {
+		this.iterator = iterator;
+		
+		this.permutate = permutate;
+		this.rotate = rotate;
+	}
+
+	public void removePermutations(int count) {
+		iterator.removePermutations(count);
+	}
+
+	public void removePermutations(List<Integer> removed) {
+		iterator.removePermutations(removed);
+	}
+
+	public int[] getPermutations() {
+		return iterator.getPermutations();
+	}
+
+	public int length() {
+		return iterator.length();
+	}
+
+	public Box get(int index) {
+		return iterator.get(index);
+	}
+
+	public int nextRotation() {
+		if(!rotate) {
+			return -1;
+		}
+		return iterator.nextRotation();
+	}
+
+	public int nextPermutation() {
+		if(!permutate) {
+			return -1;
+		}
+		return iterator.nextPermutation();
+	}
+
+	public PermutationRotationState getState() {
+		return iterator.getState();
+	}
+
+	public void setState(PermutationRotationState state) {
+		iterator.setState(state);
+	}
+	
+}


### PR DESCRIPTION
Reuse rotations where possible; if the next rotation modifies a an index within the previous result, build on that result. Only works for full levels.