### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven-surefire-plugin.version}</version>
 					<configuration>
-						<forkCount>1</forkCount>
+						<forkCount>1.5C</forkCount>
 						<reuseForks>true</reuseForks>
 						<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					</configuration>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
