### PR TITLE
Plain Packager does not respect the deadline

### DIFF
--- a/core/src/test/java/com/github/skjolber/packing/packer/AbstractPackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/AbstractPackagerTest.java
@@ -5,7 +5,9 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
+import com.github.skjolber.packing.api.Box;
 import com.github.skjolber.packing.api.Container;
+import com.github.skjolber.packing.api.StackableItem;
 
 public class AbstractPackagerTest {
 
@@ -15,10 +17,15 @@ public class AbstractPackagerTest {
 			assertValid(container);
 		}
 	}
-	
+
 	protected static void assertValid(Container container) {
 		assertNotNull(container);
 		assertThat(container).isStackedWithinContraints();
 	}
-	
+
+	protected static StackableItem box(int l, int w, int h, int count) {
+		return new StackableItem(Box.newBuilder().withRotate3D().withSize(l, w, h).withWeight(0).build(), count);
+
+	}
+
 }

--- a/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackagerTest.java
@@ -6,11 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import org.junit.jupiter.api.Test;
@@ -167,30 +163,29 @@ public class FastBruteForcePackagerTest extends AbstractPackagerTest {
 
 		FastBruteForcePackager packager = FastBruteForcePackager.newBuilder().withContainers(containers).build();
 
-		List<StackableItem> products = new ArrayList<>();
-
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(1000, 1000, 1000).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(1000,1000,1000).withWeight(1).build(), 4));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(100,1050,750).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(100,650,750).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(16,2500,11).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(250,150,80).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(280,800,480).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(30,620,10).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(40,1000,1000).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(40,100,165).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(44,575,534).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(475,530,150).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(47,3160,660).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(530,120,570).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(55,500,745).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(670,25,15).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(700,300,30).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(700,400,30).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(75,400,720).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(77,360,750).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(80,450,760).withWeight(1).build(), 1));
-		products.add(new StackableItem(Box.newBuilder().withRotate3D().withSize(90,210,680).withWeight(1).build(), 1));
+		List<StackableItem> products = Arrays.asList(
+			box(1000, 1000, 1000, 1),
+			box(1000, 1000, 1000, 4),
+			box(100, 1050, 750, 1),
+			box(100, 650, 750, 1),
+			box(16, 2500, 11, 1),
+			box(250, 150, 80, 1),
+			box(280, 800, 480, 1),
+			box(30, 620, 10, 1),
+			box(40, 1000, 1000, 1),
+			box(40, 100, 165, 1),
+			box(44, 575, 534, 1),
+			box(475, 530, 150, 1),
+			box(47, 3160, 660, 1),
+			box(530, 120, 570, 1),
+			box(55, 500, 745, 1),
+			box(670, 25, 15, 1),
+			box(700, 300, 30, 1),
+			box(700, 400, 30, 1),
+			box(75, 400, 720, 1),
+			box(77, 360, 750, 1),
+			box(80, 450, 760, 1),
+			box(90, 210, 680, 1));
 
 		// strangely when the timeout is set to now + 200ms it properly returns null
 		Container fits = packager.pack(products, System.currentTimeMillis() + 1000);

--- a/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackagerTest.java
@@ -152,7 +152,7 @@ public class FastBruteForcePackagerTest extends AbstractPackagerTest {
 		assertValid(fits);
 		assertEquals(bouwkampCode.getName(), fits.getStack().getSize(), squares.size());
 	}
-	
+
 	@Test
 	void testAnotherLargeProblemShouldRespectDeadline() {
 
@@ -189,6 +189,95 @@ public class FastBruteForcePackagerTest extends AbstractPackagerTest {
 
 		// strangely when the timeout is set to now + 200ms it properly returns null
 		Container fits = packager.pack(products, System.currentTimeMillis() + 1000);
+		assertNull(fits);
+	}
+
+	@Test
+	void testAHugeProblemShouldRespectDeadline() {
+
+		List<Container> containers = new ArrayList<>();
+
+		containers.add(Container.newBuilder().withDescription("1").withEmptyWeight(1).withSize(1900, 1500, 4000)
+			.withMaxLoadWeight(100).withStack(new ValidatingStack()).build());
+
+		FastBruteForcePackager packager = FastBruteForcePackager.newBuilder().withContainers(containers).build();
+
+		List<StackableItem> products = Arrays.asList(
+			box(1000, 12, 12,1),
+			box(1000, 14, 14,1),
+			box(100, 250, 410,2),
+			box(104, 81, 46,1),
+			box(116, 94, 48,1),
+			box(120, 188, 368,1),
+			box(1250, 4, 600,3),
+			box(1270, 870, 45,1),
+			box(135, 189, 75,2),
+			box(13, 20, 2500,4),
+			box(154, 195, 255,1),
+			box(180, 170, 75,1),
+			box(180, 60, 50,2),
+			box(225, 120, 500,2),
+			box(2500, 1200, 13,1),
+			box(2500, 30, 600,1),
+			box(250, 150, 230,1),
+			box(28, 56, 1094,3),
+			box(28, 75, 145,3),
+			box(29, 71, 112,1),
+			box(30, 30, 2000,2),
+			box(30, 75, 150,2),
+			box(310, 130, 460,10),
+			box(313, 313, 16,18),
+			box(32, 105, 163,2),
+			box(32, 73, 150,2),
+			box(355, 370, 161,1),
+			box(36, 23, 23,2),
+			box(380, 380, 130,1),
+			box(385, 140, 55,1),
+			box(38, 38, 30,6),
+			box(397, 169, 133,2),
+			box(39, 38, 28,2),
+			box(39, 66, 206,2),
+			box(40, 40, 2000,2),
+			box(410, 410, 170,1),
+			box(419, 646, 784,1),
+			box(41, 29, 24,12),
+			box(42, 34, 19,2),
+			box(44, 35, 28,6),
+			box(467, 174, 135,1),
+			box(46, 41, 24,12),
+			box(47, 44, 29,6),
+			box(49, 36, 36,2),
+			box(49, 48, 23,6),
+			box(4, 4, 2500,4),
+			box(50, 39, 25,2),
+			box(50, 49, 21,6),
+			box(52, 51, 21,6),
+			box(55, 46, 45,2),
+			box(570, 310, 85,29),
+			box(58, 32, 32,1),
+			box(614, 824, 96,1),
+			box(61, 51, 26,14),
+			box(625, 500, 50,6),
+			box(640, 510, 1200,1),
+			box(640, 960, 220,1),
+			box(65, 48, 231,2),
+			box(65, 64, 38,4),
+			box(68, 66, 39,4),
+			box(700, 325, 90,1),
+			box(71, 42, 39,4),
+			box(73, 43, 40,4),
+			box(79, 78, 46,4),
+			box(82, 80, 47,4),
+			box(84, 67, 44,4),
+			box(88, 52, 47,4),
+			box(90, 800, 2040,1),
+			box(970, 790, 2200,1));
+
+
+		final long start = System.currentTimeMillis();
+		Container fits = packager.pack(products, start + 200);
+		final long duration = System.currentTimeMillis() - start;
+		assertThat(duration).isLessThan(250);
 		assertNull(fits);
 	}
 

--- a/core/src/test/java/com/github/skjolber/packing/packer/laff/FastLargestAreaFitFirstPackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/laff/FastLargestAreaFitFirstPackagerTest.java
@@ -1,5 +1,6 @@
 package com.github.skjolber.packing.packer.laff;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -7,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.github.skjolber.packing.packer.bruteforce.FastBruteForcePackager;
 import org.junit.jupiter.api.Test;
 
 import com.github.skjolber.packing.api.Box;
@@ -170,6 +172,95 @@ public class FastLargestAreaFitFirstPackagerTest extends AbstractPackagerTest {
 		);
 
 		assertNull(packaging);
+	}
+
+	@Test
+	void testAHugeProblemShouldRespectDeadline() {
+
+		List<Container> containers = new ArrayList<>();
+
+		containers.add(Container.newBuilder().withDescription("1").withEmptyWeight(1).withSize(1900, 1500, 4000)
+			.withMaxLoadWeight(100).withStack(new ValidatingStack()).build());
+
+		FastLargestAreaFitFirstPackager packager = FastLargestAreaFitFirstPackager.newBuilder().withContainers(containers).build();
+
+		List<StackableItem> products = Arrays.asList(
+			box(1000, 12, 12,1),
+			box(1000, 14, 14,1),
+			box(100, 250, 410,2),
+			box(104, 81, 46,1),
+			box(116, 94, 48,1),
+			box(120, 188, 368,1),
+			box(1250, 4, 600,3),
+			box(1270, 870, 45,1),
+			box(135, 189, 75,2),
+			box(13, 20, 2500,4),
+			box(154, 195, 255,1),
+			box(180, 170, 75,1),
+			box(180, 60, 50,2),
+			box(225, 120, 500,2),
+			box(2500, 1200, 13,1),
+			box(2500, 30, 600,1),
+			box(250, 150, 230,1),
+			box(28, 56, 1094,3),
+			box(28, 75, 145,3),
+			box(29, 71, 112,1),
+			box(30, 30, 2000,2),
+			box(30, 75, 150,2),
+			box(310, 130, 460,10),
+			box(313, 313, 16,18),
+			box(32, 105, 163,2),
+			box(32, 73, 150,2),
+			box(355, 370, 161,1),
+			box(36, 23, 23,2),
+			box(380, 380, 130,1),
+			box(385, 140, 55,1),
+			box(38, 38, 30,6),
+			box(397, 169, 133,2),
+			box(39, 38, 28,2),
+			box(39, 66, 206,2),
+			box(40, 40, 2000,2),
+			box(410, 410, 170,1),
+			box(419, 646, 784,1),
+			box(41, 29, 24,12),
+			box(42, 34, 19,2),
+			box(44, 35, 28,6),
+			box(467, 174, 135,1),
+			box(46, 41, 24,12),
+			box(47, 44, 29,6),
+			box(49, 36, 36,2),
+			box(49, 48, 23,6),
+			box(4, 4, 2500,4),
+			box(50, 39, 25,2),
+			box(50, 49, 21,6),
+			box(52, 51, 21,6),
+			box(55, 46, 45,2),
+			box(570, 310, 85,29),
+			box(58, 32, 32,1),
+			box(614, 824, 96,1),
+			box(61, 51, 26,14),
+			box(625, 500, 50,6),
+			box(640, 510, 1200,1),
+			box(640, 960, 220,1),
+			box(65, 48, 231,2),
+			box(65, 64, 38,4),
+			box(68, 66, 39,4),
+			box(700, 325, 90,1),
+			box(71, 42, 39,4),
+			box(73, 43, 40,4),
+			box(79, 78, 46,4),
+			box(82, 80, 47,4),
+			box(84, 67, 44,4),
+			box(88, 52, 47,4),
+			box(90, 800, 2040,1),
+			box(970, 790, 2200,1));
+
+
+		final long start = System.currentTimeMillis();
+		Container fits = packager.pack(products, start + 200);
+		final long duration = System.currentTimeMillis() - start;
+		assertThat(duration).isLessThan(250);
+		assertNull(fits);
 	}
 
 }

--- a/core/src/test/java/com/github/skjolber/packing/packer/plain/PlainPackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/plain/PlainPackagerTest.java
@@ -1,5 +1,6 @@
 package com.github.skjolber.packing.packer.plain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.github.skjolber.packing.packer.bruteforce.FastBruteForcePackager;
 import org.junit.jupiter.api.Test;
 
 import com.github.skjolber.packing.api.Box;
@@ -210,4 +212,92 @@ public class PlainPackagerTest extends AbstractPackagerTest {
 		return new StackableItem(box, boxCountPerStackableItem);
 	}
 
+	@Test
+	void testAHugeProblemShouldRespectDeadline() {
+
+		List<Container> containers = new ArrayList<>();
+
+		containers.add(Container.newBuilder().withDescription("1").withEmptyWeight(1).withSize(1900, 1500, 4000)
+			.withMaxLoadWeight(100).withStack(new ValidatingStack()).build());
+
+		PlainPackager packager = PlainPackager.newBuilder().withContainers(containers).build();
+
+		List<StackableItem> products = Arrays.asList(
+			box(1000, 12, 12,1),
+			box(1000, 14, 14,1),
+			box(100, 250, 410,2),
+			box(104, 81, 46,1),
+			box(116, 94, 48,1),
+			box(120, 188, 368,1),
+			box(1250, 4, 600,3),
+			box(1270, 870, 45,1),
+			box(135, 189, 75,2),
+			box(13, 20, 2500,4),
+			box(154, 195, 255,1),
+			box(180, 170, 75,1),
+			box(180, 60, 50,2),
+			box(225, 120, 500,2),
+			box(2500, 1200, 13,1),
+			box(2500, 30, 600,1),
+			box(250, 150, 230,1),
+			box(28, 56, 1094,3),
+			box(28, 75, 145,3),
+			box(29, 71, 112,1),
+			box(30, 30, 2000,2),
+			box(30, 75, 150,2),
+			box(310, 130, 460,10),
+			box(313, 313, 16,18),
+			box(32, 105, 163,2),
+			box(32, 73, 150,2),
+			box(355, 370, 161,1),
+			box(36, 23, 23,2),
+			box(380, 380, 130,1),
+			box(385, 140, 55,1),
+			box(38, 38, 30,6),
+			box(397, 169, 133,2),
+			box(39, 38, 28,2),
+			box(39, 66, 206,2),
+			box(40, 40, 2000,2),
+			box(410, 410, 170,1),
+			box(419, 646, 784,1),
+			box(41, 29, 24,12),
+			box(42, 34, 19,2),
+			box(44, 35, 28,6),
+			box(467, 174, 135,1),
+			box(46, 41, 24,12),
+			box(47, 44, 29,6),
+			box(49, 36, 36,2),
+			box(49, 48, 23,6),
+			box(4, 4, 2500,4),
+			box(50, 39, 25,2),
+			box(50, 49, 21,6),
+			box(52, 51, 21,6),
+			box(55, 46, 45,2),
+			box(570, 310, 85,29),
+			box(58, 32, 32,1),
+			box(614, 824, 96,1),
+			box(61, 51, 26,14),
+			box(625, 500, 50,6),
+			box(640, 510, 1200,1),
+			box(640, 960, 220,1),
+			box(65, 48, 231,2),
+			box(65, 64, 38,4),
+			box(68, 66, 39,4),
+			box(700, 325, 90,1),
+			box(71, 42, 39,4),
+			box(73, 43, 40,4),
+			box(79, 78, 46,4),
+			box(82, 80, 47,4),
+			box(84, 67, 44,4),
+			box(88, 52, 47,4),
+			box(90, 800, 2040,1),
+			box(970, 790, 2200,1));
+
+
+		final long start = System.currentTimeMillis();
+		Container fits = packager.pack(products, start + 200);
+		final long duration = System.currentTimeMillis() - start;
+		assertThat(duration).isLessThan(250);
+		assertNull(fits);
+	}
 }


### PR DESCRIPTION
I stumbled on a situation in production where we don't respect our timeout (200ms) because of the Plain Packager.

Here is the test to reproduce the issue. The other packagers seem to work fine for the moment.

@skjolber what about sharing some common properties (like this one) across the different implementations ? I think we should share some test code.