### PR TITLE
Avoid creating too many array lists

### DIFF
--- a/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/ExtremePoints3DStack.java
+++ b/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/ExtremePoints3DStack.java
@@ -59,6 +59,10 @@ public class ExtremePoints3DStack extends ExtremePoints3D<StackPlacement> {
 
 		return nextStackItem.stackPlacement;
 	}
+	
+	public int getStackIndex() {
+		return stackIndex;
+	}
 
 	public void redo() {
 		// clear current level

--- a/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackager.java
+++ b/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackager.java
@@ -32,10 +32,11 @@ import com.github.skjolber.packing.packer.DefaultPackResultComparator;
 
 /**
  * Fit boxes into container, i.e. perform bin packing to a single container. This implementation tries all
- * permutations and rotations, for each selecting the perceived best placement. So it does not try all possible placements (as i not all extreme-points)-
+ * permutations and rotations, for each selecting the perceived best placement. 
+ * So it does not try all possible placements (as i not all extreme-points)-
  * <br>
  * <br>
- * Thread-safe implementation. The input Boxes must however only be used in a single thread at a time.
+ * Thread-safe implementation. The input boxes and containers must however only be used in a single thread at a time.
  */
 
 public class FastBruteForcePackager extends AbstractPackager<BruteForcePackagerResult, FastBruteForcePackagerResultBuilder> {

--- a/jmh/src/main/java/com/github/skjolber/packing/jmh/BouwkampCodeBruteForcePackagerBenchmark.java
+++ b/jmh/src/main/java/com/github/skjolber/packing/jmh/BouwkampCodeBruteForcePackagerBenchmark.java
@@ -28,23 +28,20 @@ import com.github.skjolber.packing.packer.AbstractPackager;
 @Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class BouwkampCodeBruteForcePackagerBenchmark {
 
-	/*
 	@Benchmark
 	public int parallelPackager(BouwkampCodeBruteForcePackagerState state) throws Exception {
 		return process(state.getParallelBruteForcePackager(), Long.MAX_VALUE);
 	}
-	*/
 
 	@Benchmark
 	public int packager(BouwkampCodeBruteForcePackagerState state) throws Exception {
 		return process(state.getBruteForcePackager(), Long.MAX_VALUE);
 	}
-	/*
+	
 	@Benchmark
 	public int fastPackager(BouwkampCodeBruteForcePackagerState state) throws Exception {
 		return process(state.getFastBruteForcePackager(), Long.MAX_VALUE);
 	}
-	*/
 	
 	public int process(List<BenchmarkSet> sets, long deadline) {
 		int i = 0;

--- a/jmh/src/main/java/com/github/skjolber/packing/jmh/BouwkampCodeBruteForcePackagerBenchmark.java
+++ b/jmh/src/main/java/com/github/skjolber/packing/jmh/BouwkampCodeBruteForcePackagerBenchmark.java
@@ -28,20 +28,23 @@ import com.github.skjolber.packing.packer.AbstractPackager;
 @Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class BouwkampCodeBruteForcePackagerBenchmark {
 
+	/*
 	@Benchmark
 	public int parallelPackager(BouwkampCodeBruteForcePackagerState state) throws Exception {
 		return process(state.getParallelBruteForcePackager(), Long.MAX_VALUE);
 	}
+	*/
 
 	@Benchmark
 	public int packager(BouwkampCodeBruteForcePackagerState state) throws Exception {
 		return process(state.getBruteForcePackager(), Long.MAX_VALUE);
 	}
-	
+	/*
 	@Benchmark
 	public int fastPackager(BouwkampCodeBruteForcePackagerState state) throws Exception {
 		return process(state.getFastBruteForcePackager(), Long.MAX_VALUE);
 	}
+	*/
 	
 	public int process(List<BenchmarkSet> sets, long deadline) {
 		int i = 0;


### PR DESCRIPTION
Pass current best result into the call stack, so that new results can be determined to be good enough without creating a result wrapper array list.