### PR TITLE
Added test for impossible configuration BUG

### DIFF
--- a/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/BruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/BruteForcePackagerTest.java
@@ -364,6 +364,35 @@ public class BruteForcePackagerTest extends AbstractBruteForcePackagerTest {
 		assertFalse(build.isSuccess());
 	}
 
+	@Test
+	public void testImpossible4() {
+		List<ContainerItem> containerItems = ContainerItem
+				.newListBuilder()
+				.withContainer(Container.newBuilder().withDescription("1").withEmptyWeight(1).withSize(32300, 10000, 6000)
+					.withMaxLoadWeight(50000).withStack(new ValidatingStack()).build(), 1)
+				.build();
+
+		Packager packager = BruteForcePackager.newBuilder().build();
+
+		List<StackableItem> products = Arrays.asList(
+			new StackableItem(Box.newBuilder().withRotate3D().withSize(3350, 510, 3350).withWeight(250).build(), 1),
+			new StackableItem(Box.newBuilder().withRotate3D().withSize(2600, 20500, 3600).withWeight(1200).build(), 1),
+			new StackableItem(Box.newBuilder().withRotate3D().withSize(2600, 25600, 4200).withWeight(1520).build(), 1),
+			new StackableItem(Box.newBuilder().withRotate3D().withSize(2600, 25600, 4200).withWeight(1900).build(), 1),
+			new StackableItem(Box.newBuilder().withRotate3D().withSize(2600, 25600, 4200).withWeight(1500).build(), 1),
+			new StackableItem(Box.newBuilder().withRotate3D().withSize(2600, 25600, 4200).withWeight(1420).build(), 1)
+		);
+
+		PackagerResult build = packager
+				.newResultBuilder()
+				.withContainers(containerItems)
+				.withStackables(products)
+				.withMaxContainerCount(1)
+				.build();
+
+		assertFalse(build.isSuccess());
+	}
+
 
 	@Test
 	public void testMutuallyExclusiveBoxesAndContainersForMultiContainerResult() throws Exception {


### PR DESCRIPTION
For some configurations of the container the brute force algorithm proposes incorrect solution.

Example:
Container.newBuilder().withSize(32300, 6000, 10000)
Solution not found - correct

Container.newBuilder().withSize(32300, 10000, 6000)
Solution found - incorrect

In general it seems to be caused by the smallest box as this issue is not presetn without it.

There is also screenshot form the viewer:
![image (1)](https://github.com/skjolber/3d-bin-container-packing/assets/90283242/5d4e2049-6aff-49c0-b405-4caacaafd772)
