### PR TITLE
Use System.nanoTime() instead of System.currentTimeMillis()

### DIFF
--- a/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/BruteForcePackagerResultBuilder.java
+++ b/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/BruteForcePackagerResultBuilder.java
@@ -35,7 +35,7 @@ public class BruteForcePackagerResultBuilder extends PackagerResultBuilder<Brute
 		if(items == null) {
 			throw new IllegalStateException();
 		}
-		long start = System.currentTimeMillis();
+		long start = System.nanoTime();
 
 		PackagerInterruptSupplierBuilder booleanSupplierBuilder = PackagerInterruptSupplierBuilder.builder();
 		if(deadline != -1L) {
@@ -47,7 +47,7 @@ public class BruteForcePackagerResultBuilder extends PackagerResultBuilder<Brute
 
 		PackagerInterruptSupplier build = booleanSupplierBuilder.build();
 		List<Container> packList = packager.pack(items, containers, maxContainerCount, build);
-		long duration = System.currentTimeMillis() - start;
+		long duration = (System.nanoTime() - start) / 1000000L;
 		if(packList == null) {
 			return new PackagerResult(Collections.emptyList(), duration, true);
 		}

--- a/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackagerResultBuilder.java
+++ b/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackagerResultBuilder.java
@@ -35,7 +35,7 @@ public class FastBruteForcePackagerResultBuilder extends PackagerResultBuilder<F
 		if(items == null) {
 			throw new IllegalStateException();
 		}
-		long start = System.currentTimeMillis();
+		long start = System.nanoTime();
 
 		PackagerInterruptSupplierBuilder booleanSupplierBuilder = PackagerInterruptSupplierBuilder.builder();
 		if(deadline != -1L) {
@@ -48,7 +48,7 @@ public class FastBruteForcePackagerResultBuilder extends PackagerResultBuilder<F
 		PackagerInterruptSupplier build = booleanSupplierBuilder.build();
 
 		List<Container> packList = packager.pack(items, containers, maxContainerCount, build);
-		long duration = System.currentTimeMillis() - start;
+		long duration = (System.nanoTime() - start) / 1000000L;
 		if(packList == null) {
 			return new PackagerResult(Collections.emptyList(), duration, true);
 		}

--- a/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/ParallelBruteForcePackagerResultBuilder.java
+++ b/core/src/main/java/com/github/skjolber/packing/packer/bruteforce/ParallelBruteForcePackagerResultBuilder.java
@@ -8,11 +8,11 @@ public class ParallelBruteForcePackagerResultBuilder extends BruteForcePackagerR
 
 	@Override
 	public PackagerResult build() {
-		long timestamp = System.currentTimeMillis();
+		long timestamp = System.nanoTime();
 		try {
 			return super.build();
 		} catch (ParallelBruteForcePackagerException e) {
-			return new PackagerResult(Collections.emptyList(), System.currentTimeMillis() - timestamp, false);
+			return new PackagerResult(Collections.emptyList(), (System.nanoTime() - timestamp) / 1000000L , false);
 		}
 	}
 }

--- a/core/src/main/java/com/github/skjolber/packing/packer/laff/LargestAreaFitFirstPackagerResultBuilder.java
+++ b/core/src/main/java/com/github/skjolber/packing/packer/laff/LargestAreaFitFirstPackagerResultBuilder.java
@@ -35,7 +35,7 @@ public class LargestAreaFitFirstPackagerResultBuilder extends PackagerResultBuil
 		if(items == null) {
 			throw new IllegalStateException();
 		}
-		long start = System.currentTimeMillis();
+		long start = System.nanoTime();
 
 		PackagerInterruptSupplierBuilder booleanSupplierBuilder = PackagerInterruptSupplierBuilder.builder();
 		if(deadline != -1L) {
@@ -48,7 +48,7 @@ public class LargestAreaFitFirstPackagerResultBuilder extends PackagerResultBuil
 		PackagerInterruptSupplier build = booleanSupplierBuilder.build();
 
 		List<Container> packList = packager.pack(items, containers, maxContainerCount, build);
-		long duration = System.currentTimeMillis() - start;
+		long duration = (System.nanoTime() - start) / 1000000L;
 		if(packList == null) {
 			return new PackagerResult(Collections.emptyList(), duration, true);
 		}

--- a/core/src/main/java/com/github/skjolber/packing/packer/plain/PlainPackagerResultBuilder.java
+++ b/core/src/main/java/com/github/skjolber/packing/packer/plain/PlainPackagerResultBuilder.java
@@ -35,7 +35,7 @@ public class PlainPackagerResultBuilder extends PackagerResultBuilder<PlainPacka
 		if(items == null) {
 			throw new IllegalStateException();
 		}
-		long start = System.currentTimeMillis();
+		long start = System.nanoTime();
 
 		PackagerInterruptSupplierBuilder booleanSupplierBuilder = PackagerInterruptSupplierBuilder.builder();
 		if(deadline != -1L) {
@@ -47,7 +47,7 @@ public class PlainPackagerResultBuilder extends PackagerResultBuilder<PlainPacka
 
 		PackagerInterruptSupplier build = booleanSupplierBuilder.build();
 		List<Container> packList = packager.pack(items, containers, maxContainerCount, build);
-		long duration = System.currentTimeMillis() - start;
+		long duration = (System.nanoTime() - start) / 1000000L;
 		if(packList == null) {
 			return new PackagerResult(Collections.emptyList(), duration, true);
 		}

--- a/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/BruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/BruteForcePackagerTest.java
@@ -201,10 +201,10 @@ public class BruteForcePackagerTest extends AbstractBruteForcePackagerTest {
 	protected void pack(List<BouwkampCodes> codes) {
 		for (BouwkampCodes bouwkampCodes : codes) {
 			for (BouwkampCode bouwkampCode : bouwkampCodes.getCodes()) {
-				long timestamp = System.currentTimeMillis();
+				long timestamp = System.nanoTime();
 				System.out.println("Package " + bouwkampCode.getName() + " " + bouwkampCodes.getSource());
 				pack(bouwkampCode);
-				System.out.println("Packaged " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder() + " in " + (System.currentTimeMillis() - timestamp));
+				System.out.println("Packaged " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder() + " in " + (System.nanoTime() - timestamp) / 1000000L);
 			}
 		}
 	}

--- a/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/FastBruteForcePackagerTest.java
@@ -128,10 +128,10 @@ public class FastBruteForcePackagerTest extends AbstractBruteForcePackagerTest {
 	protected void pack(List<BouwkampCodes> codes) {
 		for (BouwkampCodes bouwkampCodes : codes) {
 			for (BouwkampCode bouwkampCode : bouwkampCodes.getCodes()) {
-				long timestamp = System.currentTimeMillis();
+				long timestamp = System.nanoTime();
 				System.out.println("Package " + bouwkampCode.getName() + " " + bouwkampCodes.getSource());
 				pack(bouwkampCode);
-				System.out.println("Packaged " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder() + " in " + (System.currentTimeMillis() - timestamp));
+				System.out.println("Packaged " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder() + " in " + (System.nanoTime() - timestamp) / 1000000L);
 			}
 		}
 	}

--- a/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/ParallelBruteForcePackagerTest.java
+++ b/core/src/test/java/com/github/skjolber/packing/packer/bruteforce/ParallelBruteForcePackagerTest.java
@@ -200,9 +200,9 @@ public class ParallelBruteForcePackagerTest extends AbstractBruteForcePackagerTe
 	protected void pack(List<BouwkampCodes> codes) {
 		for (BouwkampCodes bouwkampCodes : codes) {
 			for (BouwkampCode bouwkampCode : bouwkampCodes.getCodes()) {
-				long timestamp = System.currentTimeMillis();
+				long timestamp = System.nanoTime();
 				pack(bouwkampCode);
-				System.out.println("Packaged " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder() + " in " + (System.currentTimeMillis() - timestamp));
+				System.out.println("Packaged " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder() + " in " + (System.nanoTime() - timestamp) / 1000000L);
 			}
 		}
 	}

--- a/visualizer/packaging/src/test/java/com/github/skjolber/packing/visualizer/packaging/AbstractPackagerTest.java
+++ b/visualizer/packaging/src/test/java/com/github/skjolber/packing/visualizer/packaging/AbstractPackagerTest.java
@@ -70,9 +70,9 @@ public class AbstractPackagerTest {
 				}
 				*/
 				System.out.println("Package " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder());
-				long timestamp = System.currentTimeMillis();
+				long timestamp = System.nanoTime();
 				pack(bouwkampCode, packager);
-				System.out.println("Packaged " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder() + " in " + (System.currentTimeMillis() - timestamp));
+				System.out.println("Packaged " + bouwkampCode.getName() + " order " + bouwkampCode.getOrder() + " in " + (System.nanoTime() - timestamp) / 1000000L);
 
 				Thread.sleep(5000);
 			}


### PR DESCRIPTION
Using `System.currentTimeMillis()` to measure code execution time is not a good practice because this call is linked to the system time. If the system time changes, you will get incorrect measurements. Additionally, on non-Windows operating systems, calling `System.currentTimeMillis()` incurs extra system call overhead. 

This commit replaces the calls measuring execution duration with `System.nanoTime()`.